### PR TITLE
fix: remove layout jump on page load

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ The easiest approach is to use the make your changes here on the GitHub website:
 - `source` - Name of YouTube channel, podcast, conference, blog, etc. if different from author's name (`string`; optional)
 - `topics` - Main topic(s) covered by the tutorial (`array` of `strings`; required)
 
-Where possible, please add tutorial series as one entry with a link to the series homepage.
+### What if the tutorial is part of a series?
+
+Rather than adding every tutorial in the series separately, please add the entire series as one entry that links to the series homepage (or the first tutorial in the series).
 
 ## Coming Soon
 

--- a/src/components/Directory.js
+++ b/src/components/Directory.js
@@ -240,7 +240,7 @@ function Directory({ tutorials, formats, topics, authors, sources }) {
           />
 
           {/* Lists of all formats, topics, authors and sources */}
-          <LargeScreenFilters>
+          <Sidebar>
             <FilterMenu
               heading="Formats"
               filters={formats}
@@ -268,7 +268,7 @@ function Directory({ tutorials, formats, topics, authors, sources }) {
               activeFilter={source}
               setFilter={setSource}
             />
-          </LargeScreenFilters>
+          </Sidebar>
         </LayoutGrid>
       </Container>
     </>
@@ -368,17 +368,14 @@ const HandsUp = styled(Emoji)`
 `
 
 const LayoutGrid = styled.div`
-  @supports (grid-auto-rows: 0) {
-    ${media.md`
-      display: grid;
-      grid-template-columns: 1fr auto;
-      & > ul > li { margin-right: var(--s4) }
-      & > div > section { margin-left: var(--s4) }
-    `}
+  display: grid;
+  grid-template-columns: 1fr auto;
+  & > div > section {
+    margin-left: var(--s6);
   }
 `
 
-const LargeScreenFilters = styled.div`
+const Sidebar = styled.div`
   display: none;
 
   ${media.md`

--- a/src/components/MobileMenu.js
+++ b/src/components/MobileMenu.js
@@ -41,7 +41,7 @@ function MobileMenu({
         onRequestClose={closeModal}
         closeTimeoutMS={500} // match exit animation timing
       >
-        <SmallScreenFilters>
+        <ModalContent>
           {/* Lists of all types, topics, authors and sources */}
           <FilterMenu
             heading="Formats"
@@ -70,7 +70,7 @@ function MobileMenu({
             activeFilter={currentSource}
             setFilter={setSource}
           />
-        </SmallScreenFilters>
+        </ModalContent>
       </StyledModal>
     </>
   )
@@ -146,7 +146,7 @@ const StyledModal = styled(ReactModalAdapter)`
   }
 `
 
-const SmallScreenFilters = styled.div`
+const ModalContent = styled.div`
   padding: var(--s4);
   font-size: var(--f2);
 


### PR DESCRIPTION
## Summary

It turns out the media query was unnecessary for the grid layout because the sidebar is set to `display: none` on small screens anyway. 

As a result, the grid code automatically acts as a one column layout on small screens (since the `1fr` value of the first and only column expands to fill the space) and a two-column layout on larger screens when the sidebar appears.

## Related Issues

Fixes #26 