### PR TITLE
#19 allow multiple tutorial formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ The easiest approach is to use the make your changes here on the GitHub website:
 ```yaml
 - title: 'GatsbyJS: How to Create the Fastest Sites in the World'
   link: https://www.youtube.com/watch?v=Gtd-Ht-D0sg
-  format: video
+  formats: 
+    - video
+    - text
   language: en
   date: 2017-10-01
   authors: 
@@ -41,7 +43,7 @@ The easiest approach is to use the make your changes here on the GitHub website:
 
 - `title` - Title of tutorial (`string`; required)
 - `link` - Working URL where tutorial can be found (`string`; required)
-- `format` - Media format of tutorial (`string` with the value `video`, `audio` or `text`; required)
+- `formats` - Media format of tutorial (`array` of `strings` with values `video`, `audio` or `text`; required)
 - `language` - Spoken/written language of the tutorial (`string` with a two-letter [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes); required)
 - `date` - Date tutorial was published (`string` in `YYYY-MM-DD` format; optional)
 - `authors` - Name of author(s) or speaker(s) (`array` of `strings`; optional)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2871,14 +2871,12 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "optional": true
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -7595,8 +7593,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7614,13 +7611,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7633,18 +7628,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7747,8 +7739,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7758,7 +7749,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7771,20 +7761,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7801,7 +7788,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7874,8 +7860,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7885,7 +7870,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7961,8 +7945,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7992,7 +7975,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8010,7 +7992,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8049,13 +8030,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9396,14 +9375,12 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "optional": true
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -10248,8 +10225,7 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "optional": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "string-width": {
           "version": "3.1.0",
@@ -10266,7 +10242,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -10335,9 +10310,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "rxjs": {
           "version": "6.5.2",
@@ -11347,8 +11322,7 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "optional": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "string-width": {
           "version": "3.1.0",
@@ -11365,7 +11339,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -12869,8 +12842,7 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "optional": true
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
@@ -16441,7 +16413,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "optional": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0"
       }

--- a/src/components/Directory.js
+++ b/src/components/Directory.js
@@ -27,7 +27,7 @@ function Directory({ tutorials, formats, topics, authors, sources }) {
     if (!format && !author && !source && !topic && !query) return true
 
     // Check if the tutorial matches any active filters
-    if (format && tutorial.format.includes(format)) isFormatMatch = true
+    if (format && tutorial.formats.includes(format)) isFormatMatch = true
     if (topic && tutorial.topics.includes(topic)) isTopicMatch = true
     if (author && tutorial.authors.includes(author)) isAuthorMatch = true
     if (source && tutorial.source && tutorial.source.includes(source))

--- a/src/components/Tutorial.js
+++ b/src/components/Tutorial.js
@@ -22,14 +22,10 @@ function Tutorial({
     else setSource(e.target.value)
   }
 
-  // Choose which tutorial category emoji to show next to the title
-  let tutorialEmoji
-  if (tutorial.format === `video`) {
-    tutorialEmoji = <Emoji emoji="📺" ariaLabel="Emoji of a television" />
-  } else if (tutorial.format === `audio`) {
-    tutorialEmoji = <Emoji emoji="🎧" ariaLabel="Emoji of a headphones" />
-  } else if (tutorial.format === `text`) {
-    tutorialEmoji = <Emoji emoji="📕" ariaLabel="Emoji of a hand writing" />
+  const tutorialEmojis = {
+    text: "📕",
+    video: "📺",
+    audio: "🎧",
   }
 
   return (
@@ -39,7 +35,11 @@ function Tutorial({
       </Title>
 
       <Details>
-        {tutorialEmoji}&nbsp;
+        {tutorial.formats && tutorial.formats.length > 0 && (
+          tutorial.formats.map((format, i) => (
+            <Emoji key={i} emoji={tutorialEmojis[format] || "❓"} ariaLabel={`Emoji of a ${format}`} />
+          ))
+        )}&nbsp;
         {tutorial.authors && tutorial.authors.length > 0 ? (
           tutorial.authors.map((author, i) => (
             <Fragment key={author}>
@@ -55,14 +55,14 @@ function Tutorial({
             </Fragment>
           ))
         ) : (
-          <Button
-            value={tutorial.source}
-            onClick={handleSourceClick}
-            active={tutorial.source === currentSource}
-          >
-            {tutorial.source}
-          </Button>
-        )}
+            <Button
+              value={tutorial.source}
+              onClick={handleSourceClick}
+              active={tutorial.source === currentSource}
+            >
+              {tutorial.source}
+            </Button>
+          )}
         {tutorial.date && <p>・{tutorial.date}</p>}
       </Details>
 

--- a/src/data/tutorials.yml
+++ b/src/data/tutorials.yml
@@ -1,6 +1,7 @@
 - title: Gatsby and Snipcart E-commerce Tutorial
   link: https://www.frontendstumbles.com/gatsby-and-snipcart-ecommerce-tutorial/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-07-10
   length: ''
@@ -17,7 +18,8 @@
     
 - title: Using Gatsby Image with Netlify CMS
   link: https://www.frontendstumbles.com/using-gatsby-image-with-netlify-cms/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-05-24
   length: ''
@@ -35,7 +37,8 @@
     
 - title: How to make a Gatsby site with Netlify CMS
   link: https://www.frontendstumbles.com/gatsby-and-netlify-cms-tutorial/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-05-21
   length: ''
@@ -50,7 +53,8 @@
     
 - title: How to build a Related Posts Component with Gatsby.js
   link: https://khalilstemmler.com/articles/gatsby-related-posts-component/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-04-16
   length: '7:00'
@@ -64,7 +68,8 @@
     
 - title: 'Gatsby 101 (14 written tutorials)'
   link: https://gatsbyguides.com/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-02-13
   length: ''
@@ -79,7 +84,8 @@
 
 - title: 'Gatsby and Contentful (6 videos)'
   link: https://www.youtube.com/watch?v=fY3mBJSDA44&list=PL2dKqfImstaRbjzzirbBfv9W2kycaKjvs
-  format: video
+  formats:
+    - video
   language: en
   date: 2019-02-08
   length: ''
@@ -94,7 +100,8 @@
     
 - title: 'Up & Running with Gatsby (10 videos)'
   link: https://www.youtube.com/watch?v=eCtgG5Sx6kk&list=PLs_LGDWysHJptEmAKxXjLCQvl7sAbXPBw
-  format: video
+  formats:
+    - video
   language: en
   date: 2019-06-03
   length: ''
@@ -115,7 +122,8 @@
 
 - title: Gatsby Themes Roadmap
   link: https://www.gatsbyjs.org/blog/2019-03-11-gatsby-themes-roadmap/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-03-11
   length: '6:00'
@@ -127,7 +135,8 @@
 
 - title: How to Talk About Gatsby to Clients and Your Team
   link: https://www.gatsbyjs.org/blog/2019-03-07-sell-gatsby-to-clients/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-03-07
   length: '9:00'
@@ -139,7 +148,8 @@
 
 - title: New Schema Customization API in Gatsby
   link: https://www.gatsbyjs.org/blog/2019-03-04-new-schema-customization/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-03-04
   length: '10:00'
@@ -153,7 +163,8 @@
 
 - title: A Method for Localization with Gatsby and Sanity.io
   link: https://www.gatsbyjs.org/blog/2019-03-01-localization-with-gatsby-and-sanity/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-03-01
   length: '6:00'
@@ -166,7 +177,8 @@
 
 - title: Getting Started with Gatsby Themes and MDX
   link: https://www.gatsbyjs.org/blog/2019-02-26-getting-started-with-gatsby-themes/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-02-26
   length: '6:00'
@@ -181,7 +193,8 @@
 
 - title: Introducing useStaticQuery
   link: https://www.gatsbyjs.org/blog/2019-02-20-introducing-use-static-query/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-02-20
   length: '4:00'
@@ -195,7 +208,8 @@
 
 - title: 'Behind the Scenes Q & A: What Makes Gatsby Great Webinar'
   link: https://www.gatsbyjs.org/blog/2019-02-14-behind-the-scenes-q-and-a/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-02-14
   length: '20:00'
@@ -217,7 +231,8 @@
     
 - title: 'Gatsby Themes: Watch Us Build a Theme Live'
   link: https://www.gatsbyjs.org/blog/2019-02-11-gatsby-themes-livestream-and-example/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-02-11
   length: '2:00'
@@ -232,7 +247,8 @@
 
 - title: How We're Migrating a Government Open Data Site to Gatsby
   link: https://www.gatsbyjs.org/blog/2019-02-08-government-open-data-site-with-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-02-08
   length: '12:00'
@@ -248,7 +264,8 @@
 
 - title: Using React Context API with Gatsby
   link: https://www.gatsbyjs.org/blog/2019-01-31-using-react-context-api-with-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-01-31
   length: '6:00'
@@ -262,7 +279,8 @@
 
 - title: Why Themes?
   link: https://www.gatsbyjs.org/blog/2019-01-31-why-themes/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-01-31
   length: '6:00'
@@ -274,7 +292,8 @@
 
 - title: 'Themes Update: Child Theming and Component Shadowing'
   link: https://www.gatsbyjs.org/blog/2019-01-29-themes-update-child-theming-and-component-shadowing/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-01-29
   length: '4:00'
@@ -286,7 +305,8 @@
 
 - title: Blazing Fast Development with Gatsby and Sanity.io
   link: https://www.gatsbyjs.org/blog/2019-01-25-blazing-fast-development-with-gatsby-and-sanity-io/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-01-25
   length: '6:00'
@@ -300,7 +320,8 @@
 
 - title: Modern Publications with Gatsby & Ghost
   link: https://www.gatsbyjs.org/blog/2019-01-14-modern-publications-with-gatsby-ghost/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-01-14
   length: '3:00'
@@ -315,7 +336,8 @@
 
 - title: Kentico Cloud & Gatsby Take You Beyond Static Websites
   link: https://www.gatsbyjs.org/blog/2018-12-19-kentico-cloud-and-gatsby-take-you-beyond-static-websites/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-01-07
   length: '7:00'
@@ -330,7 +352,8 @@
 
 - title: How Gatsby Scales with your Expertise & Scope
   link: https://www.gatsbyjs.org/blog/2018-12-19-gatsby-scales-with-expertise-and-scope/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-01-03
   length: '4:00'
@@ -342,7 +365,8 @@
 
 - title: Publish Multiple Gatsby Sites in a Monorepo, Using Lerna, Travis & Now
   link: https://www.gatsbyjs.org/blog/2019-01-01-publish-multiple-gatsby-sites/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-01-01
   length: '26:00'
@@ -363,7 +387,8 @@
 
 - title: Per-Link Gatsby Page Transitions with TransitionLink
   link: https://www.gatsbyjs.org/blog/2018-12-04-per-link-gatsby-page-transitions-with-transitionlink/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-12-27
   length: '6:00'
@@ -376,7 +401,8 @@
 
 - title: 'Turning the Static Dynamic: Gatsby + Netlify Functions + Netlify Identity'
   link: https://www.gatsbyjs.org/blog/2018-12-17-turning-the-static-dynamic/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-12-26
   length: '11:00'
@@ -394,7 +420,8 @@
 
 - title: Building a Custom, Accessible Image Lightbox
   link: https://www.gatsbyjs.org/blog/2018-11-03-building-an-accessible-lightbox/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-12-20
   length: '7:00'
@@ -408,7 +435,8 @@
     
 - title: How to Export a Drupal Site to Gatsby
   link: https://www.gatsbyjs.org/blog/2018-10-26-export-a-drupal-site-to-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-12-18
   length: '7:00'
@@ -422,7 +450,8 @@
 
 - title: 5 Analogies That Explain What Gatsby Can Do For You
   link: https://www.gatsbyjs.org/blog/2018-12-04-gatsby-analogy/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-12-04
   length: '5:00'
@@ -434,7 +463,8 @@
 
 - title: "Deploy a Static React Blog using GatsbyJS and Github"
   link: https://hashnode.com/post/deploy-a-static-react-blog-using-gatsbyjs-and-github-cjg2vzpe0003h0ls1rdaztnrr
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-04-16
   length: ''
@@ -449,7 +479,8 @@
 
 - title: 'Generate Documentation for any React Project Using GatsbyJS'
   link: https://hashnode.com/post/generate-documentation-for-any-react-project-using-gatsbyjs-cjmcjqhfv00d6ges1m6ljzpud
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-09-21
   length: ''
@@ -464,7 +495,8 @@
 
 - title: 'Gatsby ImageSharp from a URL'
   link: https://blog.alexluong.com/gatsby-image-sharp-from-url
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-07-28
   length: ''
@@ -479,7 +511,8 @@
 
 - title: 'Animating Page Transitions in Gatsby'
   link: https://divdev.io/animating-gatsby-pt/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-12-01
   length: '5:00'
@@ -494,7 +527,8 @@
 
 - title: 'Using Excerpts'
   link: https://using-remark.gatsbyjs.org/excerpts/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-11-14
   length: '1:00'
@@ -506,7 +540,8 @@
 
 - title: 'How To Optimize Your Gatsby Blog For SEO'
   link: https://khalilstemmler.com/blog/how-to-optimize-your-gatsby-blog-for-seo/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-12-01
   length: ''
@@ -519,7 +554,8 @@
 
 - title: 'An Introduction To Using Gatsby Image & Gatsby.js V2'
   link: https://codebushi.com/using-gatsby-image/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-09-20
   length: ''
@@ -532,7 +568,8 @@
 
 - title: 'Image Optimization Made Easy with Gatsby.js'
   link: https://medium.com/@kyle.robert.gill/ridiculously-easy-image-optimization-with-gatsby-js-59d48e15db6e
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-01-10
   length: '6:00'
@@ -545,7 +582,8 @@
 
 - title: 'Cool image loading with Gatsby.js v2 and Netlify CMS v2'
   link: https://blog.rousek.name/2018/08/10/cool-image-loading-with-gatsbyjs-v2-and-netlify-cms-v2/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-08-10
   length: ''
@@ -559,7 +597,8 @@
 
 - title: 'Pump up the JAM with Gatsby'
   link: https://www.youtube.com/watch?v=fwTxNylQhn8
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-10-20
   length: '45:34'
@@ -574,7 +613,8 @@
 
 - title: 'The Complete Guide to Build a Full Blown Multilanguage Website with Gatsby.js'
   link: https://www.storyblok.com/tp/gatsby-multilanguage-website-tutorial
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-11-14
   length: ''
@@ -589,7 +629,8 @@
 
 - title: 'How I Made My Portfolio Website Blazing Fast with Gatsby'
   link: https://medium.freecodecamp.org/how-i-made-my-portfolio-website-blazing-fast-with-gatsby-82ccddc2f671
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-08-12
   length: '7:00'
@@ -603,7 +644,8 @@
 
 - title: 'Easy Gatsby Image Components'
   link: https://noahgilmore.com/blog/easy-gatsby-image-components/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-11-01
   length: ''
@@ -616,7 +658,8 @@
 
 - title: 'How To Build A Gatsby Site From The Ground Up: Comprehensive Step-By-Step Tutorial'
   link: https://justinformentin.com/guide-to-building-a-gatsby-site
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-30
   length: '41:00'
@@ -654,7 +697,8 @@
     
 - title: 'All You Need to Know About i18n with Gatsby'
   link: https://phraseapp.com/blog/posts/i18n-with-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-12-14
   length: ''
@@ -670,7 +714,8 @@
     
 - title: 'Creating Your First Gatsby Theme'
   link: https://blog.alexluong.com/creating-your-first-gatsby-theme
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-11-29
   length: ''
@@ -684,7 +729,8 @@
 
 - title: 'How To Build A Blog From Scratch With React, Markdown, GraphQL and GatsbyJS'
   link: https://medium.com/crowdbotics/how-to-build-your-own-blog-from-scratch-with-gatsbyjs-graphql-react-and-markdown-78352c367bd1
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-11-21
   length: '10:00'
@@ -699,7 +745,8 @@
     - v2
 - title: 'Implement i18n to a Gatsby Site'
   link: https://www.obytes.com/blog/2018/implement-i18n-to-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-07
   length: '15:00'
@@ -714,7 +761,8 @@
     - react-intl
 - title: 'Build a Blog Using Gatsby.js & React'
   link: https://codeburst.io/build-a-blog-using-gatsby-js-react-8561bfe8fc91
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-09-27
   length: '14:00'
@@ -736,7 +784,8 @@
     
 - title: 'GatsbyJS: How to Create the Fastest Sites in the World'
   link: https://www.youtube.com/watch?v=Gtd-Ht-D0sg
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-10-01
   length: '24:52'
@@ -749,7 +798,8 @@
 
 - title: Moving My Personal Site To GatsbyJS
   link: https://www.youtube.com/watch?v=xqaThBnesfY
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-07-10
   length: '54:05'
@@ -762,7 +812,8 @@
 
 - title: Build Blazingly Fast Websites with Gatsby
   link: https://devmode.fm/episodes/build-blazingly-fast-websites-with-gatsby
-  format: audio
+  formats:
+    - audio
   language: en
   date: 2018-10-15
   length: '1:06:52'
@@ -777,7 +828,8 @@
 
 - title: Add a Chat Widget to Your Gatsby Blog
   link: https://pusher.com/tutorials/chat-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-05-31
   length: ''
@@ -790,7 +842,8 @@
 
 - title: Improving Gatsby Blog Deploy UX
   link: https://benmccormick.org/2017/11/07/blog-deploy-ux/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-11-07
   length: ''
@@ -802,7 +855,8 @@
 
 - title: Adding RSS, Atom, and JSON Feed to Gatsby
   link: https://benmccormick.org/2017/06/03/rss-atom-json-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-06-03
   length: ''
@@ -814,7 +868,8 @@
 
 - title: Getting Started with GatsbyJS
   link: https://www.youtube.com/watch?v=nufLF1kcn_4
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-11-09
   length: '1:24:35'
@@ -827,7 +882,8 @@
 
 - title: React-Based Content Management with Netlify CMS & Gatsby
   link: https://www.youtube.com/watch?v=YyRwMy59d4M
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-03-30
   length: '27:34'
@@ -839,7 +895,8 @@
 
 - title: Learn Gatsby.js
   link: https://kalinchernev.github.io/learn-gatsbyjs/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-10-03
   length: '15:00'
@@ -852,7 +909,8 @@
 
 - title: Building a Photo Site With GatsbyJS and the WordPress.com API
   link: https://jeremey.blog/gatsby-photo/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-12-11
   length: '18:00'
@@ -868,7 +926,8 @@
 
 - title: Experimenting With GatsbyJS and the WordPress.com API
   link: https://jeremey.blog/gatsbyjs-and-wp-com-api/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-12-07
   length: '4:00'
@@ -882,7 +941,8 @@
 
 - title: 'A Step-by-Step Guide: Gatsby on Netlify'
   link: https://www.netlify.com/blog/2016/02/24/a-step-by-step-guide-gatsby-on-netlify/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-06-23
   length: ''
@@ -894,7 +954,8 @@
 
 - title: Build a Blog with React and Markdown using Gatsby (13 videos)
   link: https://egghead.io/courses/build-a-blog-with-react-and-markdown-using-gatsby
-  format: video
+  formats:
+    - video
   language: en
   date: null
   length: '31:00'
@@ -907,7 +968,8 @@
 
 - title: 'Gatsby, Static Site Generator For React: Introduction'
   link: https://www.youtube.com/watch?v=rBlH1UvluiU
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-12-02
   length: '31:44'
@@ -920,7 +982,8 @@
 
 - title: A First Look at Gatsby, a Static Site Generator for React
   link: https://www.youtube.com/watch?v=CSemYFzHAtU
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-07-07
   length: '19:30'
@@ -933,7 +996,8 @@
 
 - title: 'Gatsby, Static Site Generator: Tutorial (13 videos)'
   link: https://www.youtube.com/playlist?list=PLLAZ4kZ9dFpMXuwazIt4mWtTuqOHdjRlk
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-09-19
   length: '75:31'
@@ -946,7 +1010,8 @@
 
 - title: GatsbyJS Tutorials (9 videos)
   link: https://www.youtube.com/playlist?list=PLLnpHn493BHHfoINKLELxDch3uJlSapxg
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-10-04
   length: '107:38'
@@ -960,7 +1025,8 @@
 
 - title: 'Open Source Lightning Talk: Gatsby'
   link: https://www.youtube.com/watch?v=y588qNiCZZo
-  format: video
+  formats:
+    - video
   language: en
   date: 2016-11-03
   length: '8:12'
@@ -973,7 +1039,8 @@
 
 - title: Static site generation with Gatsby.js
   link: https://www.youtube.com/watch?v=y588qNiCZZo
-  format: video
+  formats:
+    - video
   language: en
   date: 2016-03-30
   length: '25:29'
@@ -987,7 +1054,8 @@
 
 - title: 'Lightning Talks: Kyle Matthews'
   link: https://www.youtube.com/watch?v=RFkNRKL6ZoE
-  format: video
+  formats:
+    - video
   language: en
   date: 2016-02-25
   length: '6:13'
@@ -1000,7 +1068,8 @@
 
 - title: How We Got Here and The Future of the Web
   link: https://www.youtube.com/watch?v=1tjvFldRg6A
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-12-07
   length: '34:11'
@@ -1012,7 +1081,8 @@
 
 - title: The Journey to the Content Mesh
   link: https://www.youtube.com/watch?v=1JqNymVi_pc
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-12-07
   length: '33:49'
@@ -1026,7 +1096,8 @@
 
 - title: Introducing Gatsby Themes
   link: https://www.youtube.com/watch?v=wX84vXBpMR8
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-12-07
   length: '33:47'
@@ -1038,7 +1109,8 @@
 
 - title: 'Gatsby Product Announcement: The Future is in the Cloud'
   link: https://www.youtube.com/watch?v=TXxUAJkBrjE
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-12-07
   length: '15:42'
@@ -1050,7 +1122,8 @@
 
 - title: Introducing Gatsby Themes
   link: https://www.gatsbyjs.org/blog/2018-11-11-introducing-gatsby-themes/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-11-10
   length: '5:00'
@@ -1062,7 +1135,8 @@
 
 - title: Gatsby for Apps
   link: https://www.gatsbyjs.org/blog/2018-11-07-gatsby-for-apps/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-11-07
   length: '11:00'
@@ -1074,7 +1148,8 @@
 
 - title: Deploying a Gatsby Blog to Azure
   link: https://www.gatsbyjs.org/blog/2018-11-05-deploying-gatsby-to-azure/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-11-05
   length: '5:00'
@@ -1087,7 +1162,8 @@
 
 - title: Using Unstructured Data in Gatsby
   link: https://www.gatsbyjs.org/blog/2018-10-25-unstructured-data/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-25
   length: '9:00'
@@ -1100,7 +1176,8 @@
 
 - title: Using VS Code for Supercharged Gatsby.js Development
   link: https://www.gatsbyjs.org/blog/2018-10-18-vscode-gatsby-development/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-22
   length: '5:00'
@@ -1112,7 +1189,8 @@
 
 - title: 'Delivering Modern Website Experiences: The Journey to a Content Mesh'
   link: https://www.gatsbyjs.org/blog/2018-10-04-journey-to-the-content-mesh
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-04
   length: '4:00'
@@ -1125,7 +1203,8 @@
 
 - title: 'Journey to the Content Mesh, Part 2: Unbundling of the CMS'
   link: https://www.gatsbyjs.org/blog/2018-10-10-unbundling-of-the-cms
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-10
   length: '3:00'
@@ -1138,7 +1217,8 @@
 
 - title: 'Journey to the Content Mesh, Part 3: The Rise of Modern Web Development'
   link: https://www.gatsbyjs.org/blog/2018-10-11-rise-of-modern-web-development
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-11
   length: '4:00'
@@ -1150,7 +1230,8 @@
 
 - title: 'Journey to the Content Mesh, Part 4: Why Mobile Performance Is Crucial'
   link: https://www.gatsbyjs.org/blog/2018-10-16-why-mobile-performance-is-crucial
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-16
   length: '7:00'
@@ -1162,7 +1243,8 @@
 
 - title: 'Journey to the Content Mesh Conclusion: Creating Compelling Content Experiences'
   link: https://www.gatsbyjs.org/blog/2018-10-18-creating-compelling-content-experiences/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-18
   length: '7:00'
@@ -1175,7 +1257,8 @@
 
 - title: 'Beyond Static: Building Dynamic Apps with Gatsby'
   link: https://www.youtube.com/watch?v=BrBK4yxodXA
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-10-23
   length: '59:19'
@@ -1188,7 +1271,8 @@
 
 - title: SendGrid Knowledge Center cuts page load times in half with Gatsby
   link: https://www.gatsbyjs.org/blog/2018-09-27-sendgrid-knowledge-center-cuts-page-load-times-in-half-with-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-23
   length: '4:00'
@@ -1200,7 +1284,8 @@
 
 - title: 'Web Performance 102: Keeping Gatsby Sites Blazing Fast'
   link: https://www.gatsbyjs.org/blog/2018-10-03-gatsby-perf/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-03
   length: '8:00'
@@ -1213,7 +1298,8 @@
 
 - title: How We Improved Gatsby's Accessibility in v2 by Switching to @reach/router
   link: https://www.gatsbyjs.org/blog/2018-09-27-reach-router/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-09-27
   length: '4:00'
@@ -1226,7 +1312,8 @@
 
 - title: Announcing Support for Natively Querying 3rd-Party GraphQL APIs with Gatsby
   link: https://www.gatsbyjs.org/blog/2018-09-25-announcing-graphql-stitching-support/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-09-25
   length: '5:00'
@@ -1239,7 +1326,8 @@
 
 - title: GatsbyJS with Creator Kyle Mathews
   link: https://www.lullabot.com/podcasts/drupalizeme-podcast/gatsbyjs-with-creator-kyle-mathews
-  format: audio
+  formats:
+    - audio
   language: en
   date: 2018-08-16
   length: '58:48'
@@ -1252,7 +1340,8 @@
 
 - title: Announcing Gatsby 2.0.0 🎉🎉🎉
   link: https://www.gatsbyjs.org/blog/2018-09-17-gatsby-v2/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-09-17
   length: '9:00'
@@ -1264,7 +1353,8 @@
 
 - title: What Kind of Company Will We Be? A Look at Gatsby’s Mission and Values.
   link: https://www.gatsbyjs.org/blog/2018-09-07-gatsby-values/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-09-07
   length: '9:00'
@@ -1276,7 +1366,8 @@
 
 - title: Publishing Your Next Gatsby Site to AWS With AWS Amplify
   link: https://www.gatsbyjs.org/blog/2018-08-24-gatsby-aws-hosting/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-09-04
   length: '3:00'
@@ -1288,7 +1379,8 @@
 
 - title: Using Decoupled Drupal with Gatsby
   link: https://www.gatsbyjs.org/blog/2018-08-13-using-decoupled-drupal-with-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-08-13
   length: '3:00'
@@ -1300,7 +1392,8 @@
 
 - title: My Experience Doing Pair Programming with the Gatsby Team and Why You Should Do It
   link: https://www.gatsbyjs.org/blog/2018-08-11-gatsby-pair-programming/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-08-11
   length: '3:00'
@@ -1312,7 +1405,8 @@
 
 - title: Free Swag for Gatsby Contributors
   link: https://www.gatsbyjs.org/blog/2018-08-09-swag-store/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-08-09
   length: '5:00'
@@ -1325,7 +1419,8 @@
 
 - title: Learning How to Code with Gatsby
   link: https://www.gatsbyjs.org/blog/2018-07-07-graphic-design-class/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-07-07
   length: '6:00'
@@ -1337,7 +1432,8 @@
 
 - title: Automatically Create Pages from Components in any Directory
   link: https://www.gatsbyjs.org/blog/2018-07-07-the-gatsby-plugin-page-creator/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-07-07
   length: '4:00'
@@ -1349,7 +1445,8 @@
 
 - title: 'Escalade Sports: From $5000 to $5/month in Hosting With Gatsby'
   link: https://www.gatsbyjs.org/blog/2018-06-14-escalade-sports-from-5000-to-5-in-hosting/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-06-21
   length: '3:00'
@@ -1362,7 +1459,8 @@
 
 - title: Life After Layouts
   link: https://www.gatsbyjs.org/blog/2018-06-08-life-after-layouts/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-06-19
   length: '6:00'
@@ -1375,7 +1473,8 @@
 
 - title: Moving from create-react-app to Gatsby.js
   link: https://www.gatsbyjs.org/blog/2018-06-18-moving-from-create-react-app-to-gatsby-js/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-06-18
   length: '6:00'
@@ -1388,7 +1487,8 @@
 
 - title: Why Narative Loves Gatsby
   link: https://www.gatsbyjs.org/blog/2018-06-18-why-narative-loves-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-06-18
   length: '5:00'
@@ -1400,7 +1500,8 @@
 
 - title: Gatsby for Marketers, Managers, Agencies and Teams
   link: https://www.gatsbyjs.org/blog/2018-06-08-gatsby-marketers-managers-agencies-teams/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-06-08
   length: '2:00'
@@ -1412,7 +1513,8 @@
 
 - title: Introduction to Gatsby
   link: https://www.gatsbyjs.org/blog/2017-05-31-introduction-to-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-05-31
   length: '3:00'
@@ -1424,7 +1526,8 @@
 
 - title: Gatsby JS Crash Course
   link: https://www.youtube.com/watch?v=6YhqQ2ZW1sc
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-04-12
   length: '1:04:33'
@@ -1437,7 +1540,8 @@
 
 - title: Build a Gatsby Blog Using the Cosmic JS Source Plugin
   link: https://www.gatsbyjs.org/blog/2018-06-07-build-a-gatsby-blog-using-the-cosmic-js-source-plugin/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-06-07
   length: '8:00'
@@ -1451,7 +1555,8 @@
 
 - title: Build a Blazing Fast Website with GatsbyJS and Contentful
   link: https://www.youtube.com/watch?v=wlIdop5Yv_Y
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-06-25
   length: '1:08:41'
@@ -1465,7 +1570,8 @@
 
 - title: How to Use GatsbyJS for Static Site Rendering
   link: https://www.youtube.com/watch?v=3jeznGJHenI
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-09-22
   length: '1:08:41'
@@ -1477,7 +1583,8 @@
 
 - title: Using GraphQL in a Static Site Generator
   link: https://www.youtube.com/watch?v=7S8RNnTGdzI
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-08-27
   length: '28:17'
@@ -1490,7 +1597,8 @@
 
 - title: 'Gatsby: Full Tutorial for Beginners'
   link: https://www.youtube.com/watch?v=mHFAM0CXviE
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-10-23
   length: '1:11:15'
@@ -1503,7 +1611,8 @@
 
 - title: Build a Gatsby.js and Deploy with Netlify
   link: https://www.youtube.com/watch?v=THkkdFSffiw
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-03-14
   length: '5:42'
@@ -1516,7 +1625,8 @@
 
 - title: 'GatsbyJS: Dynamic Apps, Static Files, Unreal Performance'
   link: https://www.youtube.com/watch?v=OU56cuFKh94
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-10-07
   length: '57:40'
@@ -1528,7 +1638,8 @@
 
 - title: Static Site Generation With Gatsby.js
   link: https://www.heavybit.com/library/podcasts/jamstack-radio/ep-22-static-site-generation-with-gatsbyjs/
-  format: audio
+  formats:
+    - audio
   language: en
   date: 2017-11-02
   length: '34:10'
@@ -1540,7 +1651,8 @@
 
 - title: Gotchas of Gatsby.js
   link: https://www.youtube.com/watch?v=oDEFkUJ1h_c
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-07-18
   length: '35:34'
@@ -1552,7 +1664,8 @@
 
 - title: 'Review: GatsbyJS - Static site generator for ReactJS'
   link: https://www.youtube.com/watch?v=HHRTL8NMFVo
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-07-09
   length: '14:52'
@@ -1564,7 +1677,8 @@
 
 - title: Gatsby v2 Updates
   link: https://www.youtube.com/watch?v=jhLiFF4Q6vM
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-05-29
   length: '18:09'
@@ -1577,7 +1691,8 @@
 
 - title: How to Upgrade Gatsby from v1 to v2
   link: https://www.youtube.com/watch?v=Le_olZW_Vro
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-08-06
   length: '14:31'
@@ -1590,7 +1705,8 @@
 
 - title: 'GatsbyJS: A Powerful FE Tool for Decoupled Devs'
   link: https://www.youtube.com/watch?v=UgWBJnbZ9jU
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-07-15
   length: '53:03'
@@ -1602,7 +1718,8 @@
 
 - title: 'Gatsby Inkstreaming: Refactoring lengstorf.com'
   link: https://www.youtube.com/playlist?list=PLz8Iz-Fnk_eQ1VgnbqODjaO8SiWYGGPQb
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-10-07
   length: '9:06:10'
@@ -1615,7 +1732,8 @@
 
 - title: Creating Nodes in GatsbyJS with Two Data Sources Using the sourceNode API
   link: https://www.youtube.com/watch?v=a916SAaHXPQ
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-09-14
   length: '1:34:20'
@@ -1628,7 +1746,8 @@
 
 - title: Build a Podcast Mashup App Using OneGraph and Gatsby
   link: https://www.youtube.com/watch?v=10jeoEWy-8g
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-10-10
   length: '1:04:30'
@@ -1643,7 +1762,8 @@
 
 - title: Katie Builds Her First Gatsby Website
   link: https://www.youtube.com/watch?v=oH6qy9Wjj9A
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-10-12
   length: '1:30:15'
@@ -1657,7 +1777,8 @@
 
 - title: Deploy a Site With the AWS Amplify CLI
   link: https://www.youtube.com/watch?v=nujYbwyz-_A
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-09-20
   length: '33:24'
@@ -1670,7 +1791,8 @@
 
 - title: Pro Gatsby Preview
   link: https://www.youtube.com/playlist?list=PLLnpHn493BHFkuP4cVybiMWO67Hqq6vJI
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-03-05
   length: '43:30'
@@ -1683,7 +1805,8 @@
 
 - title: How Gatsby and Next.js Really Work (and What it Means for Speed and SEO)
   link: https://www.youtube.com/watch?v=IFHj3hIVYng
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-07-11
   length: '12:47'
@@ -1696,7 +1819,8 @@
 
 - title: Gatsby.js + WordPress
   link: https://www.youtube.com/playlist?list=PLUBR53Dw-Ef8fe-8xJXtMpd1-uhgd2Qa6
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-04-14
   length: '2:17:16'
@@ -1710,7 +1834,8 @@
 
 - title: Gatsby v2 Deep Dive with Kyle Mathews
   link: https://www.youtube.com/watch?v=QQZDr_RiiTg
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-08-27
   length: '31:24'
@@ -1723,7 +1848,8 @@
 
 - title: GatsbyJS Meetup
   link: https://www.youtube.com/watch?v=7M-7GlQGeGc
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-08-23
   length: '31:24'
@@ -1736,7 +1862,8 @@
 
 - title: Making Open Source More Open
   link: https://www.youtube.com/watch?v=extv915_vYI
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-08-27
   length: '9:10'
@@ -1748,7 +1875,8 @@
 
 - title: Work-in-Progress Gatsby Store Live Demo
   link: https://www.youtube.com/watch?v=MMF0zUqBjPQ
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-06-27
   length: '24:36'
@@ -1762,7 +1890,8 @@
 
 - title: Data in Gatsby v2
   link: https://www.youtube.com/watch?v=nlqF3p2l894
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-08-27
   length: '20:10'
@@ -1776,7 +1905,8 @@
 
 - title: Build a Gatsby v2 Site
   link: https://www.youtube.com/watch?v=gSRK9CZRIxk
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-08-27
   length: '10:48'
@@ -1792,7 +1922,8 @@
 
 - title: 5 Questions about Gatsby.js
   link: https://www.youtube.com/watch?v=SN1i8-kJYg0
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-06-22
   length: '5:46'
@@ -1804,7 +1935,8 @@
 
 - title: 'Gatsby v2: Faster build times, Guess.js, and more!'
   link: https://www.youtube.com/watch?v=cX3CldSwWmc
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-09-27
   length: '59:43'
@@ -1819,7 +1951,8 @@
 
 - title: 'Headless Drupal: Building Blazing-Fast Websites with React/GatsbyJS + Drupal'
   link: https://www.youtube.com/watch?v=TuVeWTieJGI
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-10-23
   length: '50:33'
@@ -1832,7 +1965,8 @@
 
 - title: Build a Gatsby Website in Less than 5 Mins!
   link: https://www.youtube.com/watch?v=iLRB3yIF9DY
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-08-26
   length: '4:25'
@@ -1846,7 +1980,8 @@
 
 - title: Building Blazing Fast Websites with React, Gatsby, and Contentful
   link: https://www.youtube.com/watch?v=3bRsd175KNI
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-10-23
   length: '11:26'
@@ -1859,7 +1994,8 @@
 
 - title: 'GatsbyJS: Pros and Cons and In-Between'
   link: https://www.youtube.com/watch?v=3Rx1IIjJJ6w
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-02-20
   length: '1:11:34'
@@ -1872,7 +2008,8 @@
 
 - title: How to Create a Recommended Articles Section in GatsbyJS
   link: https://www.youtube.com/watch?v=bz-ZzmNkoO8
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-06-28
   length: '25:54'
@@ -1884,7 +2021,8 @@
 
 - title: How to Make a Contact Form in Gatsby with Netlify
   link: https://www.youtube.com/watch?v=hF7xJhzrr9s
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-03-09
   length: '13:24'
@@ -1897,7 +2035,8 @@
 
 - title: 'GatsbyJS: Make Blazingly Fast Static Websites with React'
   link: https://www.youtube.com/watch?v=4InJKj1g_-c
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-08-08
   length: '23:03'
@@ -1909,7 +2048,8 @@
 
 - title: Bring React to Your Static Websites with Gatsby.js
   link: https://www.youtube.com/watch?v=aeyOKv-N500
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-06-06
   length: '23:33'
@@ -1921,7 +2061,8 @@
 
 - title: Discovering GatsbyJS
   link: https://www.youtube.com/watch?v=9969CImxtBQ
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-07-11
   length: '1:10:26'
@@ -1934,7 +2075,8 @@
 
 - title: Intro to Gatsby.js
   link: https://www.youtube.com/watch?v=TJ09SYDuvfo
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-08-28
   length: '27:05'
@@ -1947,7 +2089,8 @@
 
 - title: Gatsby UX Research
   link: https://www.youtube.com/watch?v=dTl817c6G_E
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-05-29
   length: '17:27'
@@ -1959,7 +2102,8 @@
 
 - title: Building Websites with Gatsby
   link: https://www.youtube.com/watch?v=AQGzRqYJa8k
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-02-21
   length: '37:45'
@@ -1971,7 +2115,8 @@
 
 - title: Create a Gatsby Source Plugin
   link: https://www.youtube.com/watch?v=5HHa-R-Jq3s
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-05-23
   length: '8:52'
@@ -1985,7 +2130,8 @@
 
 - title: 'GatsbyJS: Static Site Generator for React'
   link: https://www.youtube.com/watch?v=PAnYxgoMc6c
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-09-22
   length: '6:30'
@@ -1997,7 +2143,8 @@
 
 - title: Kyle Mathews, Gatsby, Wordpress, GraphQL and Web Performance by Default
   link: https://www.youtube.com/watch?v=kY-dxi_6stQ
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-03-23
   length: '33:26'
@@ -2011,7 +2158,8 @@
 
 - title: Static Sites with Gatsby
   link: https://www.youtube.com/watch?v=UobFjlQOCOQ
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-10-30
   length: '47:39'
@@ -2024,7 +2172,8 @@
 
 - title: Gatsby v2
   link: https://www.youtube.com/watch?v=wVfgN-oXdVA
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-10-18
   length: '28:30'
@@ -2036,7 +2185,8 @@
 
 - title: 'Gatsby: A React.js Static Site Generator'
   link: https://www.youtube.com/watch?v=G4LVKJOOj7o
-  format: video
+  formats:
+    - video
   language: en
   date: 2016-04-18
   length: '49:48'
@@ -2049,7 +2199,8 @@
 
 - title: 'Episode 39: Gatsby'
   link: https://www.orbit.fm/weboftomorrow/39
-  format: audio
+  formats:
+    - audio
   language: en
   date: 2017-08-07
   length: '48:15'
@@ -2062,7 +2213,8 @@
 
 - title: Dealing with the Limitations of Gatsby Source Drupal
   link: https://www.youtube.com/watch?v=qhrA6ftyFpM
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-08-27
   length: '26:06'
@@ -2074,7 +2226,8 @@
 
 - title: Refactoring My Gatsby Starter to v2
   link: https://www.youtube.com/watch?v=Htk7dduynDY
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-10-08
   length: '2:06:00'
@@ -2086,7 +2239,8 @@
 
 - title: 'Episode 13: Gatsby'
   link: https://www.youtube.com/watch?v=aqv4_iewECM
-  format: video
+  formats:
+    - video
   language: en
   date: 2017-07-17
   length: '5:08'
@@ -2098,7 +2252,8 @@
 
 - title: Build a Portfolio Website with Netlify and NetlifyCMS (3 videos)
   link: https://www.youtube.com/watch?v=wmLDUWNs63w&t=0s&list=PLuJHeJTDddjlO8JCSfITdCy1mZsZnZcKS&index=2
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-06-21
   length: '37:53'
@@ -2111,7 +2266,8 @@
 
 - title: Deploying Your First Gatsby Site to Netlify
   link: https://www.youtube.com/watch?v=TbQ4kWX29lQ
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-10-23
   length: '13:16'
@@ -2125,7 +2281,8 @@
 
 - title: Decoupled Drupal + Gatsby
   link: https://www.youtube.com/watch?v=fx2Qo3D47tI
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-08-25
   length: '1:00:32'
@@ -2139,7 +2296,8 @@
  
 - title: How to Write a Gatsby Source Plugin (featuring Cat Facts)
   link: https://medium.com/@cwlsn/how-to-write-a-gatsby-source-plugin-featuring-cat-facts-f0c769a10bfd
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-11-13
   length: '6:00'
@@ -2155,7 +2313,8 @@
   
 - title: 'JAMstack Basics: How to Create a Gatsby Starter with Contentful and Deploy to Netlify'
   link: https://itnext.io/jamstack-basics-how-to-create-a-gatsby-starter-with-contentful-and-deploy-to-netlify-846354cc74bc
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-10
   length: '9:00'
@@ -2173,7 +2332,8 @@
 
 - title: Official Gatsby.js Tutorial
   link: https://www.gatsbyjs.org/tutorial/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-09-08
   length: ''
@@ -2187,7 +2347,8 @@
 
 - title: WordPress Source Plugin Tutorial
   link: https://www.gatsbyjs.org/docs/wordpress-source-plugin-tutorial/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-16
   length: ''
@@ -2200,7 +2361,8 @@
 
 - title: Adding Images to a WordPress Site
   link: https://www.gatsbyjs.org/docs/image-tutorial/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-16
   length: ''
@@ -2212,7 +2374,8 @@
 
 - title: Source Plugin Tutorial
   link: https://www.gatsbyjs.org/docs/source-plugin-tutorial/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-11-06
   length: ''
@@ -2228,7 +2391,8 @@
 
 - title: Gatsby E-Commerce Tutorial
   link: https://www.gatsbyjs.org/docs/ecommerce-tutorial/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-10-26
   length: ''
@@ -2243,7 +2407,8 @@
 
 - title: Making a Site with User Authentication
   link: https://www.gatsbyjs.org/docs/authentication-tutorial/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-11-06
   length: ''
@@ -2257,7 +2422,8 @@
 
 - title: 'JAMstack PWA : Let’s Build a Polling App with Gatsby.js, Firebase and Styled-Components, Part 1'
   link: https://medium.com/@UnicornAgency/jamstack-pwa-lets-build-a-polling-app-with-gatsby-js-firebase-and-styled-components-pt-1-78a03a633092
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-02-20
   length: '13:00'
@@ -2273,7 +2439,8 @@
 
 - title: 'JAMstack PWA : Let’s Build a Polling App with Gatsby.js, Firebase and Styled-Components, Part 2'
   link: https://medium.com/@UnicornAgency/jamstack-pwa-lets-build-a-polling-app-with-gatsby-js-firebase-and-styled-components-pt-2-9044534ea6bc
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-04-17
   length: '11:00'
@@ -2292,7 +2459,8 @@
 
 - title: 'JAMstack PWA : Let’s Build a Polling App with Gatsby.js, Firebase and Styled-Components, Part 3'
   link: https://medium.com/@UnicornAgency/jamstack-pwa-lets-build-a-polling-app-with-gatsby-js-firebase-and-styled-components-pt-3-89fa499534fd
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-05-08
   length: '5:00'
@@ -2308,7 +2476,8 @@
 
 - title: Building a Blog with Gatsby, React and Webtask.io!
   link: https://medium.com/@UnicornAgency/jamstack-pwa-lets-build-a-polling-app-with-gatsby-js-firebase-and-styled-components-pt-3-89fa499534fd
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-03-01
   length: ''
@@ -2329,7 +2498,8 @@
 
 - title: 'A PWA Example: Build an E-Commerce Progressive Web App with Gatsby'
   link: https://snipcart.com/blog/pwa-example-ecommerce-gatsby
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-07-03
   length: ''
@@ -2347,7 +2517,8 @@
 
 - title: Creating a Static E-Commerce Website with Snipcart, GatsbyJS and DatoCMS
   link: https://snipcart.com/blog/static-ecommerce-gatsby-datocms
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-06-18
   length: ''
@@ -2364,7 +2535,8 @@
 
 - title: Handling Static Forms, Auth & Serverless Functions with Gatsby on Netlify
   link: https://snipcart.com/blog/static-forms-serverless-gatsby-netlify
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-04-25
   length: ''
@@ -2382,7 +2554,8 @@
 
 - title: ReactJS E-Commerce with No Backend Using Snipcart & Gatsby
   link: https://snipcart.com/blog/snipcart-reactjs-static-ecommerce-gatsby
-  format: text
+  formats:
+    - text
   language: en
   date: 2016-01-28
   length: ''
@@ -2397,7 +2570,8 @@
 
 - title: Announcing New Gatsby Company
   link: https://www.gatsbyjs.org/blog/2018-05-24-launching-new-gatsby-company/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-05-24
   length: '10:00'
@@ -2409,7 +2583,8 @@
 
 - title: Six Reasons I Chose Gatsby
   link: https://www.gatsbyjs.org/blog/2018-05-11-six-reasons-i-chose-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-05-11
   length: '4:00'
@@ -2421,7 +2596,8 @@
 
 - title: Building Eviction Free NYC with GatsbyJS + Contentful
   link: https://www.gatsbyjs.org/blog/2018-04-27-building-eviction-free-nyc-with-gatsbyjs-and-contentful/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-04-27
   length: '8:00'
@@ -2439,7 +2615,8 @@
 
 - title: How Gatsby Changes Teams' Website Development Workflow
   link: https://www.gatsbyjs.org/blog/2018-04-25-how-gatsby-changes-teams-website-development-workflow/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-04-25
   length: '4:00'
@@ -2453,7 +2630,8 @@
 
 - title: Trying Out Gatsby at Work & Co
   link: https://www.gatsbyjs.org/blog/2018-04-11-trying-out-gatsby-at-work-and-co/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-04-11
   length: '15:00'
@@ -2473,7 +2651,8 @@
 
 - title: Gatsby + Contentful Starter to Get a Website Up and Running in 5 Minutes
   link: https://www.gatsbyjs.org/blog/2018-04-04-gatsby-contentful-starter-tutorial/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-04-04
   length: '5:00'
@@ -2487,7 +2666,8 @@
 
 - title: Migration to GatsbyJS and JAM stack from WordPress
   link: https://www.gatsbyjs.org/blog/2018-03-29-migration-from-wordpress-to-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-03-29
   length: '11:00'
@@ -2501,7 +2681,8 @@
 
 - title: 'Case Study: Mike Johnston for Colorado'
   link: https://www.gatsbyjs.org/blog/2018-3-03-case-study-mike-johnston/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-03-03
   length: '8:00'
@@ -2514,7 +2695,8 @@
 
 - title: Why I Upgraded My Website to GatsbyJS from Jekyll
   link: https://www.gatsbyjs.org/blog/2018-2-27-why-i-upgraded-my-website-to-gatsbyjs-from-jekyll/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-02-27
   length: '9:00'
@@ -2527,7 +2709,8 @@
 
 - title: 'Gatsby and the JAMstack: A Bright Future for the Web'
   link: https://www.gatsbyjs.org/blog/2018-02-16-bright-future-for-the-web/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-02-16
   length: '4:00'
@@ -2544,7 +2727,8 @@
 
 - title: How to Build a Website with React
   link: https://www.gatsbyjs.org/blog/2018-2-16-how-to-build-a-website-with-react/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-02-16
   length: '3:00'
@@ -2556,7 +2740,8 @@
 
 - title: Announcing Gatsby Manor, themes for Gatsby 🎉🎊
   link: https://www.gatsbyjs.org/blog/2018-02-09-announcing-gatsby-manor-themes-for-gatsbyjs/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-02-09
   length: '3:00'
@@ -2568,7 +2753,8 @@
 
 - title: Picking a Back-End for GatsbyJS
   link: https://www.gatsbyjs.org/blog/2018-2-6-choosing-a-back-end/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-02-06
   length: '12:00'
@@ -2586,7 +2772,8 @@
 
 - title: Building Sites with Headless CMSs
   link: https://www.gatsbyjs.org/blog/2018-2-3-sites-with-headless-cms/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-02-03
   length: '7:00'
@@ -2603,7 +2790,8 @@
 
 - title: Building a Site with React and Contentful
   link: https://www.gatsbyjs.org/blog/2018-1-25-building-a-site-with-react-and-contentful/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-01-25
   length: '8:00'
@@ -2617,7 +2805,8 @@
 
 - title: Getting Started with Gatsby and WordPress
   link: https://www.gatsbyjs.org/blog/2018-01-22-getting-started-gatsby-and-wordpress/
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-01-22
   length: '7:00'
@@ -2633,7 +2822,8 @@
 
 - title: 'Building a Static Blog using Gatsby and Strapi (Written tutorial with 8 videos)'
   link: https://blog.strapi.io/building-a-static-website-using-gatsby-and-strapi/
-  format: text, video
+  formats:
+    - text, video
   language: en
   date: 2019-02-27
   length: ''
@@ -2654,7 +2844,8 @@
     
 - title: 'Gatsby.js: How to set up and use the React Static Site Generator'
   link: https://medium.freecodecamp.org/setting-up-and-getting-used-to-gatsby-1fc27985ae8a
-  format: text
+  formats:
+    - text
   language: en
   date: 2018-01-05
   length: '06:00'
@@ -2670,7 +2861,8 @@
 
 - title: Gatsby + Contentful + Netlify (and Algolia)
   link: https://www.gatsbyjs.org/blog/2017-12-06-gatsby-plus-contentful-plus-netlify/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-12-06
   length: '11:00'
@@ -2689,7 +2881,8 @@
 
 - title: Taking Gatsby for a Spin
   link: https://www.gatsbyjs.org/blog/2017-12-07-taking-gatsby-for-a-spin/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-12-06
   length: '8:00'
@@ -2701,7 +2894,8 @@
 
 - title: Why I Created My Blog with Gatsby and Contentful
   link: https://www.gatsbyjs.org/blog/2017-11-09-why-i-created-my-blog-with-gatsby-and-contentful/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-11-09
   length: '13:00'
@@ -2718,7 +2912,8 @@
 
 - title: Migrate from Jekyll to Gatsby
   link: https://www.gatsbyjs.org/blog/2017-11-08-migrate-from-jekyll-to-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-11-08
   length: '4:00'
@@ -2733,7 +2928,8 @@
 
 - title: Migrate from Hugo to Gatsby
   link: https://www.gatsbyjs.org/blog/2017-11-06-migrate-hugo-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-11-06
   length: '11:00'
@@ -2753,7 +2949,8 @@
 
 - title: From WordPress to Developing in React — Starting to See It
   link: https://www.gatsbyjs.org/blog/2017-10-20-from-wordpress-to-developing-in-react-starting-to-see-it/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-10-20
   length: '5:00'
@@ -2765,7 +2962,8 @@
 
 - title: Building i18n with Gatsby
   link: https://www.gatsbyjs.org/blog/2017-10-17-building-i18n-with-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-10-17
   length: '7:00'
@@ -2779,7 +2977,8 @@
 
 - title: Making Website Building Fun
   link: https://www.gatsbyjs.org/blog/2017-10-16-making-website-building-fun/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-10-16
   length: '9:00'
@@ -2793,7 +2992,8 @@
 
 - title: Rebuilding my Portfolio Website with the Great GatsbyJS and WordPress
   link: https://www.gatsbyjs.org/blog/2017-10-05-portfolio-site-gatsby-wordpress/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-10-05
   length: '4:00'
@@ -2806,7 +3006,8 @@
 
 - title: Migrating My Blog from Hexo to Gatsby
   link: https://www.gatsbyjs.org/blog/2017-10-01-migrating-my-blog-from-hexo-to-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-10-01
   length: '17:00'
@@ -2823,7 +3024,8 @@
 
 - title: Modern Static Site Generation with Gatsby
   link: https://www.gatsbyjs.org/blog/2017-09-18-gatsby-modern-static-generation/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-09-18
   length: '7:00'
@@ -2835,7 +3037,8 @@
 
 - title: Web Performance 101—also, why is Gatsby so fast?
   link: https://www.gatsbyjs.org/blog/2017-09-13-why-is-gatsby-so-fast/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-09-13
   length: '12:00'
@@ -2848,7 +3051,8 @@
 
 - title: Creating a Blog with Gatsby
   link: https://www.gatsbyjs.org/blog/2017-07-19-creating-a-blog-with-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-07-19
   length: '18:00'
@@ -2865,7 +3069,8 @@
 
 - title: Announcing Gatsby 1.0.0 🎉🎉🎉
   link: https://www.gatsbyjs.org/blog/gatsby-v1/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-07-06
   length: '9:00'
@@ -2879,7 +3084,8 @@
 
 - title: Gatsbygram Case Study
   link: https://www.gatsbyjs.org/blog/gatsbygram-case-study/
-  format: text
+  formats:
+    - text
   language: en
   date: 2017-03-09
   length: '13:00'
@@ -2894,7 +3100,8 @@
 
 - title: 'Gatsby on AWS, the right way'
   link: https://blog.joshwalsh.me/aws-gatsby/
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-01-10
   authors: 
@@ -2908,7 +3115,8 @@
 
 - title: 'Create a Localized Website using Gatsby and Cosmic JS'
   link: https://cosmicjs.com/articles/create-a-localized-website-using-gatsby-and-cosmic-js
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-05-03
   length: '10:00'
@@ -2922,7 +3130,8 @@
 
 - title: 'How to build an Ecommerce Website using Gatsby and Cosmic JS'
   link: https://cosmicjs.com/articles/how-to-build-an-ecommerce-website-using-gatsby-and-cosmic-js-jv1b1y52
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-05-01
   length: '12:00'
@@ -2936,7 +3145,8 @@
     
 - title: 'How to Build a Documentation App With Gatsby and Cosmic JS'
   link: https://cosmicjs.com/articles/how-to-build-a-documentation-app-with-gatsby-and-cosmic-js-jrb4den5
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-02-11
   length: '10:00'
@@ -2952,7 +3162,8 @@
     
 - title: 'Video: Build a Cosmic JS-powered blog using Gatsby'
   link: https://cosmicjs.com/articles/video-build-a-cosmic-js-powered-blog-using-gatsby-jpsrqozy
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-12-17
   length: '60:00'
@@ -2968,7 +3179,8 @@
  
 - title: 'Webinar Video: Localization with Gatsby and Cosmic JS'
   link: https://cosmicjs.com/articles/webinar-video-localization-with-gatsby-and-cosmic-js-jnyqtjoa
-  format: video
+  formats:
+    - video
   language: en
   date: 2018-11-01
   length: '45:00'
@@ -2984,7 +3196,8 @@
     
 - title: 'Building and Designing a Portfolio Site Using Gatsby JS and Cosmic JS'
   link: https://cosmicjs.com/articles/building-and-designing-a-portfolio-site-using-gatsby-js-and-cosmic-js
-  format: text
+  formats:
+    - text
   language: en
   date: 2019-05-13
   length: '12:00'

--- a/src/data/tutorials.yml
+++ b/src/data/tutorials.yml
@@ -2823,7 +2823,8 @@
 - title: 'Building a Static Blog using Gatsby and Strapi (Written tutorial with 8 videos)'
   link: https://blog.strapi.io/building-a-static-website-using-gatsby-and-strapi/
   formats:
-    - text, video
+    - text
+    - video
   language: en
   date: 2019-02-27
   length: ''

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,9 +7,14 @@ function IndexPage() {
   // TODO: replace these runtime calculations with detailed YAML version once we're compiling these lists at build time
 
   // Create a sorted list of all unique formats
+  const formatArrays = tutorials.map(tutorial => tutorial.node.formats)
   const formats = [
-    ...new Set(tutorials.map(tutorial => tutorial.node.format.toLowerCase()))
-  ].sort()
+    ...new Set(
+      formatArrays
+        .reduce((acc, curr) => [...acc, ...curr]) // merge arrays into one
+        .map(format => format.toLowerCase()) // convert all formats to lowercase
+    )
+  ].sort();
 
   // Create a sorted list of all unique topics
   const topicArrays = tutorials.map(tutorial => tutorial.node.topics)

--- a/src/queries/useTutorialsData.js
+++ b/src/queries/useTutorialsData.js
@@ -10,7 +10,7 @@ function useTutorialsData() {
             node {
               title
               link
-              format
+              formats
               date(formatString: "MMM DD, YYYY")
               length
               authors
@@ -28,7 +28,7 @@ function useTutorialsData() {
             node {
               title
               link
-              format
+              formats
               language
               date(formatString: "MMM DD, YYYY")
               length


### PR DESCRIPTION
## __Summary__

Fixes #19 
Allow tutorials to include multiple formats (e.g. "text" and "video") instead of just one.

## __Description__
1. Rename all of the format fields in src/data/tutorials.yml to formats (i.e. add an "s")
2. Convert all of the formats values to an array of strings (rather than a single string)
3. Update the construction of the formats list to work with the new array format
4. Update the logic that assigns an emoji to each tutorial to show multiple emoji
5. Update README.md instructions
6. Also ran npm audit fix to fix 4/5 security issues

![image](https://user-images.githubusercontent.com/17176370/63501074-e79c7200-c4c2-11e9-8282-70a6afd443a9.png)
