### PR TITLE
Generate filter lists at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Rather than adding every tutorial in the series separately, please add the entir
 ### Better performance ⚡️
 
 - [ ] Paginate tutorials list (and search results)
-- [ ] Generate filter lists at build time
+- [x] ~Generate filter lists at build time~
 
 ### Better search 🕵️‍♂️
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,3 +1,6 @@
+// 1. Generate string versions of tutorial array fields for faster search
+///////////////////////////////////////////////////////////////////////////////////
+
 exports.onCreateNode = ({ node, actions }) => {
   const { createNodeField } = actions
 
@@ -18,6 +21,129 @@ exports.onCreateNode = ({ node, actions }) => {
       node,
       name: `authorsAsString`,
       value: node.authors ? node.authors.join(` `).toLowerCase() : ``
+    })
+  }
+}
+
+// 2. Reorder the tutorials and generate the lists of unique filters
+///////////////////////////////////////////////////////////////////////////////////
+
+let indexPageContext = {}
+
+exports.createPages = async ({ graphql, reporter }) => {
+  const result = await graphql(
+    `
+      {
+        tutorialsWithDates: allTutorialsYaml(
+          filter: { date: { ne: null } }
+          sort: { fields: [date], order: DESC }
+        ) {
+          nodes {
+            title
+            link
+            formats
+            date(formatString: "MMM DD, YYYY")
+            length
+            authors
+            source
+            topics
+            fields {
+              authorsAsString
+              formatsAsString
+              topicsAsString
+            }
+          }
+        }
+
+        tutorialsWithoutDates: allTutorialsYaml(
+          filter: { date: { eq: null } }
+          sort: { fields: [title], order: ASC }
+        ) {
+          nodes {
+            title
+            link
+            formats
+            language
+            date(formatString: "MMM DD, YYYY")
+            length
+            authors
+            source
+            topics
+            fields {
+              authorsAsString
+              formatsAsString
+              topicsAsString
+            }
+          }
+        }
+      }
+    `
+  )
+
+  // Handle errors
+  if (result.errors) {
+    reporter.panicOnBuild(`Error while running GraphQL query.`)
+    return
+  }
+
+  // Move tutorials with no date to the end of the list
+  const { tutorialsWithDates, tutorialsWithoutDates } = result.data
+  const tutorials = [...tutorialsWithDates.nodes, ...tutorialsWithoutDates.nodes]
+
+  // Create a sorted list of all unique formats
+  const formatArrays = tutorials.map(tutorial => tutorial.formats)
+  const formats = [
+    ...new Set(
+      formatArrays
+        .reduce((acc, curr) => [...acc, ...curr]) // merge arrays into one
+        .map(format => format.toLowerCase()) // convert all formats to lowercase
+    )
+  ].sort()
+
+  // Create a sorted list of all unique topics
+  const topicArrays = tutorials.map(tutorial => tutorial.topics)
+  const topics = [
+    ...new Set(
+      topicArrays
+        .reduce((acc, curr) => [...acc, ...curr]) // merge arrays into one
+        .map(topic => topic.toLowerCase()) // convert all topics to lowercase
+    )
+  ].sort()
+
+  // Create a sorted list of all unique authors
+  const authorArrays = tutorials.map(tutorial => tutorial.authors)
+  const authors = [
+    ...new Set(
+      authorArrays.reduce((acc, curr) => [...acc, ...curr]) // merge arrays
+    )
+  ].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())) // ignore case
+
+  // Create a sorted list of all unique sources
+  const sources = [
+    ...new Set(tutorials.map(tutorial => (tutorial.source ? tutorial.source : '')))
+  ].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())) // ignore case
+
+  // Will add this object to the index page context in .onCreatePage() below:
+  indexPageContext = {
+    tutorials: tutorials,
+    formats: formats,
+    topics: topics,
+    authors: authors,
+    sources: sources
+  }
+}
+
+// 3. Add processed tutorials and filter lists to the index page context
+///////////////////////////////////////////////////////////////////////////////////
+
+exports.onCreatePage = ({ page, actions }) => {
+  const { createPage, deletePage } = actions
+
+  if (page.path === `/`) {
+    deletePage(page)
+    createPage({
+      ...page,
+      context: indexPageContext
     })
   }
 }

--- a/src/components/Directory.js
+++ b/src/components/Directory.js
@@ -132,7 +132,7 @@ function Directory({ tutorials, formats, topics, authors, sources }) {
 ///////////////////////////////////////////////////////////////////////////////////
 
 function filterTutorials(tutorials, format, topic, author, source) {
-  return tutorials.filter(({ node: tutorial }) => {
+  return tutorials.filter(tutorial => {
     const isFormatMatch =
       format && tutorial.formats && new Set(tutorial.formats).has(format)
 
@@ -157,7 +157,7 @@ function filterTutorials(tutorials, format, topic, author, source) {
 function searchFilteredTutorials(filteredTutorials, query) {
   if (!query) return filteredTutorials
 
-  return filteredTutorials.filter(({ node: tutorial }) => {
+  return filteredTutorials.filter(tutorial => {
     function wordExistsInTutorial(word) {
       const isTitleMatch =
         tutorial.title && tutorial.title.toLowerCase().includes(word.toLowerCase())

--- a/src/components/Tutorials.js
+++ b/src/components/Tutorials.js
@@ -24,8 +24,8 @@ function Tutorials({
     <List>
       {tutorials.map(tutorial => (
         <Tutorial
-          key={tutorial.node.title + tutorial.node.date}
-          tutorial={tutorial.node}
+          key={tutorial.title + tutorial.date}
+          tutorial={tutorial}
           currentFormat={currentFormat}
           currentTopic={currentTopic}
           currentAuthor={currentAuthor}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,45 +1,5 @@
-function IndexPage() {
-  const [tutorialsWithDates, tutorialsWithoutDates] = useTutorialsData()
-
-  // Move tutorials with no date to the end of the list
-  const tutorials = [...tutorialsWithDates, ...tutorialsWithoutDates]
-
-  // TODO: replace these runtime calculations with detailed YAML version once we're compiling these lists at build time
-
-  // Create a sorted list of all unique formats
-  const formatArrays = tutorials.map(tutorial => tutorial.node.formats)
-  const formats = [
-    ...new Set(
-      formatArrays
-        .reduce((acc, curr) => [...acc, ...curr]) // merge arrays into one
-        .map(format => format.toLowerCase()) // convert all formats to lowercase
-    )
-  ].sort();
-
-  // Create a sorted list of all unique topics
-  const topicArrays = tutorials.map(tutorial => tutorial.node.topics)
-  const topics = [
-    ...new Set(
-      topicArrays
-        .reduce((acc, curr) => [...acc, ...curr]) // merge arrays into one
-        .map(topic => topic.toLowerCase()) // convert all topics to lowercase
-    )
-  ].sort()
-
-  // Create a sorted list of all unique authors
-  const authorArrays = tutorials.map(tutorial => tutorial.node.authors)
-  const authors = [
-    ...new Set(
-      authorArrays.reduce((acc, curr) => [...acc, ...curr]) // merge arrays
-    )
-  ].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())) // ignore case
-
-  // Create a sorted list of all unique sources
-  const sources = [
-    ...new Set(
-      tutorials.map(tutorial => (tutorial.node.source ? tutorial.node.source : ''))
-    )
-  ].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())) // ignore case
+function IndexPage({ pageContext }) {
+  const { tutorials, formats, topics, authors, sources } = pageContext
 
   return (
     <Base>
@@ -71,6 +31,5 @@ import styled from 'styled-components'
 
 import Base from '../components/Base'
 import Directory from '../components/Directory'
-import useTutorialsData from '../queries/useTutorialsData'
 
 export default IndexPage


### PR DESCRIPTION
Generates the lists that populate the filter menus at build time (in `gatsby-node.js`) rather than on the client side (in `index.js`) to speed up the site's initial rendering time my reducing client side work.

---

Resolves #25.