### PR TITLE
Alias react-dom to @hot-loader/react-dom in development

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -147,3 +147,18 @@ exports.onCreatePage = ({ page, actions }) => {
     })
   }
 }
+
+// Temporary: Alias react-dom to @hot-loader/react-dom to remove console warning
+///////////////////////////////////////////////////////////////////////////////////
+
+exports.onCreateWebpackConfig = ({ stage, actions }) => {
+  if (stage.startsWith('develop')) {
+    actions.setWebpackConfig({
+      resolve: {
+        alias: {
+          'react-dom': '@hot-loader/react-dom',
+        },
+      },
+    })
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1551,6 +1551,17 @@
         "@hapi/hoek": "8.x.x"
       }
     },
+    "@hot-loader/react-dom": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-MsOdCBB7c5YNyB4iDDct+tS7AihvYyfwZVV+z/QnbTjPgxH98kqIDXO92nU7tLXp0OtYFErHZfcWjtszP/572w==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.15.0"
+      }
+    },
     "@jimp/bmp": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.6.8.tgz",
@@ -17935,7 +17946,6 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
       "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
-      "optional": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "not op_mini all"
   ],
   "dependencies": {
+    "@hot-loader/react-dom": "^16.9.0",
     "@svgr/webpack": "^4.3.3",
     "autoprefixer": "^9.6.1",
     "babel-plugin-styled-components": "^1.10.6",


### PR DESCRIPTION
Implements [this temporary solution](https://github.com/gatsbyjs/gatsby/issues/11934#issuecomment-538662592) to address the following warning that otherwise appears during development:

```sh
react-🔥-dom patch is not detected. React 16.6+ features may not work
```